### PR TITLE
Fix duplicate team label in PodMonitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove duplicate `application.giantswarm.io/team` label in PodMonitor that caused install failure. The label is already included via the common labels helper.
+
 ## [0.1.1] - 2026-02-19
 
 ### Changed

--- a/helm/aws-ebs-csi-driver-servicemonitors/templates/controller.yaml
+++ b/helm/aws-ebs-csi-driver-servicemonitors/templates/controller.yaml
@@ -3,7 +3,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
   labels:
-    application.giantswarm.io/team: {{ .Values.team }}
     {{- include "aws-ebs-csi-driver-servicemonitors.labels" . | nindent 4 }}
   name: aws-ebs-csi-driver-controller
   namespace: kube-system


### PR DESCRIPTION
## Summary

- Remove duplicate `application.giantswarm.io/team` label from PodMonitor in `controller.yaml`
- The label was set both directly from `.Values.team` (line 6) and via the `aws-ebs-csi-driver-servicemonitors.labels` helper (which includes it from `Chart.Annotations`)
- This caused a YAML unmarshal error during Helm install: `mapping key "application.giantswarm.io/team" already defined at line 6`

## Test plan

- [ ] `helm template` renders without duplicate labels
- [ ] Deploy chart and verify PodMonitor is created successfully